### PR TITLE
CVX: Fix MathJax URL

### DIFF
--- a/CVX/CVX.html
+++ b/CVX/CVX.html
@@ -12559,7 +12559,9 @@ dependencies: [
 
 <!-- Loading mathjax macro -->
 <!-- Load mathjax -->
-    <script src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+    <script type="text/javascript"
+      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+    </script>
     <!-- MathJax configuration -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({


### PR DESCRIPTION
The CVX presentation is currently broken due to a bad MathJax URL. Updated to use the MathJax CDN.
