### PR TITLE
Corrected Pass to solver: stuff matrices objective function

### DIFF
--- a/CVX/CVX.html
+++ b/CVX/CVX.html
@@ -12392,7 +12392,7 @@ conic constraint: false
 \begin{array}{ll}
 \mbox{minimize} &amp; 
     \begin{bmatrix}
-    0 &amp; 0 &amp; 1 &amp; x
+    0 &amp; 0 &amp; 1 &amp; 0
     \end{bmatrix}
     \begin{bmatrix}
     v_1 \\ v_2 \\ v_3 \\ x

--- a/CVX/CVX.ipynb
+++ b/CVX/CVX.ipynb
@@ -10373,7 +10373,7 @@
       "\\begin{array}{ll}\n",
       "\\mbox{minimize} & \n",
       "    \\begin{bmatrix}\n",
-      "    0 & 0 & 1 & x\n",
+      "    0 & 0 & 1 & 0\n",
       "    \\end{bmatrix}\n",
       "    \\begin{bmatrix}\n",
       "    v_1 \\\\ v_2 \\\\ v_3 \\\\ x\n",


### PR DESCRIPTION
@madeleineudell 
Under the Heading **Pass to solver: stuff matrices**
The objective function is 
minimize v3

but the current version gives
minimize v3 + square(x)
